### PR TITLE
Refactored questions and answers to use hooks and refresh on new product

### DIFF
--- a/client/src/components/QandA/AddAnswer.js
+++ b/client/src/components/QandA/AddAnswer.js
@@ -107,7 +107,7 @@ class AddAnswer extends React.Component {
           <div>
           <button id='closeModal' onClick={this.closeForm}>X</button>
             <h2>Add an answer</h2>
-            <p styles={{fontWeight: 'bold'}}>{this.props.name} : {this.props.question.question_body}</p>
+            <p styles={{fontWeight: 'bold'}}>Product: {this.props.question.question_body}</p>
             <label>* Your Answer: </label>
             <textarea id='answerInputText' name='answer' type='text' onChange={(e) => {this.charsLeft(e)}} maxLength='1000' required />
             <p id='charsLeft'>{this.state.chars} characters remaining</p>

--- a/client/src/components/QandA/AddQuestion.js
+++ b/client/src/components/QandA/AddQuestion.js
@@ -85,7 +85,7 @@ class AddQuestion extends React.Component {
           <div>
             <button id='closeModal' onClick={this.closeForm}>X</button>
             <h2>Ask your question</h2>
-            <h4>About the {this.props.name}</h4>
+            <h4>About the Product</h4>
             <label>* Your Question: </label>
             <textarea id='questionInputText' name='question' type='text' onChange={(e) => {this.charsLeft(e)}} maxLength='1000' required />
             <p id='charsLeft'>{this.state.chars} characters remaining</p>

--- a/client/src/components/QandA/Answers.js
+++ b/client/src/components/QandA/Answers.js
@@ -1,76 +1,67 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import AnswerPhotos from './AnswerPhotos.js'
 
-class Answers extends React.Component {
-  constructor(props) {
-    super(props)
+const Answers = (props) => {
+  const [answers, setAnswers] = useState([]);
+  const [moreAnswers, setMoreAnswers] = useState(false);
+  const [helpful, setHelpful] = useState(false);
+  const [answerMarkedHelpful, setAnswerMarkedHelpful] = useState([]);
+  const [aReported, setAReported] = useState([]);
 
-    this.state = {
-      answers: [],
-      moreAnswers: false,
-      helpful: false,
-      answerMarkedHelpful: [],
-      aReported: []
-    }
-    this.getMore = this.getMore.bind(this)
-    this.collapse = this.collapse.bind(this)
-    this.reportAnswer = this.reportAnswer.bind(this)
-    this.escape = this.escape.bind(this)
-    this.getAnswers = this.getAnswers.bind(this)
-  }
+  useEffect(() => {
+    setMoreAnswers(false)
+    getAnswers();
+  }, [props.questionId])
 
-  getAnswers() {
-    const id = this.props.questionId
+
+  const getAnswers = () => {
+    const id = props.questionId
     axios.get(`/qa/questions/${id}/answers`)
     .then ((answersArr) => {
-      this.setState({answers: answersArr.data.results})
+      setAnswers(answersArr.data.results)
     })
     .catch ((err) => {
       console.log(err)
     })
   }
 
-  componentDidMount() {
-    this.getAnswers()
+  const getMore = () => {
+    setMoreAnswers(true)
   }
 
-  getMore() {
-    this.setState({moreAnswers: true})
+  const collapse = () => {
+    setMoreAnswers(false)
   }
 
-  collapse() {
-    this.setState({moreAnswers: false})
-  }
-
-  markHelpful(answer) {
-    const prevMarked = this.state.answerMarkedHelpful
+  const markHelpful = (answer) => {
+    const prevMarked = answerMarkedHelpful
     const id = answer.answer_id;
     if (prevMarked.includes(answer.answer_id)) {
       return;
     } else {
-      this.setState({answerMarkedHelpful: [...prevMarked, answer.answer_id]})
+      setAnswerMarkedHelpful([...prevMarked, answer.answer_id])
       axios.put(`qa/answers/${id}/helpful`, null)
       answer.helpfulness += 1
     }
   }
 
-  reportAnswer(answer) {
-    const prevReported = this.state.aReported;
+  const reportAnswer = (answer) => {
+    const prevReported = aReported;
     const id = answer.answer_id;
-    this.setState({aReported: [...prevReported, answer.answer_id]})
+    setAReported([...prevReported, answer.answer_id])
     axios.put(`qa/answers/${id}/report`, null)
     answer.reported = true;
   }
 
-  escape (html) {
+  const escape = (html) => {
     return String(html)
       .replace(new RegExp("&"+"#"+"x27;", "g"), "'")
   }
 
-  renderAnswer(answer, index) {
-    const tempBody = (this.escape(answer.body))
-    const report = (this.state.aReported.includes(answer.answer_id))
+  const renderAnswer = (answer, index) => {
+    const tempBody = (escape(answer.body))
+    const report = (aReported.includes(answer.answer_id))
     const aDate = new Date(answer.date)
     return (
       <div className='answerContainer' key={index}>
@@ -87,11 +78,11 @@ class Answers extends React.Component {
               ,{' '} {aDate.toDateString().substring(4)}
               </p>
               <p id='answerHelpful' className='answererInfo'>| Helpful?
-                <span id='helpfulButton' onClick={() => this.markHelpful(answer)}> Yes </span>
+                <span id='helpfulButton' onClick={() => markHelpful(answer)}> Yes </span>
                 ({answer.helpfulness}) {' | '}
                 {!report ?
                   (
-                  <span id='reportButton' onClick={() => this.reportAnswer(answer)}>Report</span>
+                  <span id='reportButton' onClick={() => reportAnswer(answer)}>Report</span>
                   ) :
                   (
                   <span>Reported</span>
@@ -107,11 +98,11 @@ class Answers extends React.Component {
                 by {' '} {answer.answerer_name}, {' '} {aDate.toDateString().substring(4)}
               </p>
               <p id='answerHelpful' className='answererInfo'>| Helpful?
-                <span id='helpfulButton' onClick={() => this.markHelpful(answer)}> Yes </span>
+                <span id='helpfulButton' onClick={() => markHelpful(answer)}> Yes </span>
                 ({answer.helpfulness}) {' | '}
                 {!report ?
                   (
-                  <span id='reportButton' onClick={() => this.reportAnswer(answer)}>Report</span>
+                  <span id='reportButton' onClick={() => reportAnswer(answer)}>Report</span>
                   ) :
                   (
                   <span>Reported</span>
@@ -125,34 +116,34 @@ class Answers extends React.Component {
     )
   }
 
-  render () {
-    if (this.props.questionId !== undefined) {
-      var storeAnswers = this.props.answers
-      return (
-        <div>
-          {!this.state.moreAnswers ?
-            (
-              <div>
-                {this.state.answers.slice(0, 2).map((answer, index) =>
-                (this.renderAnswer(answer, index)))}
-                {this.state.answers.length > 2 ? <a id='moreAnswers' onClick={this.getMore}>More answers...</a> : null}
-              </div>
-            )
-            :
-            (
-              <div>
-                  {this.state.answers.map((answer, index) => (this.renderAnswer(answer, index)))}
-                  {this.state.answers.length > 2 ? <a id='moreAnswers' onClick={this.collapse}>Collapse answers</a> : null}
-              </div>
-            )
 
-          }
-        </div>
-      )
-    } else {
-      return (<div>Loading answers...</div>)
-    }
+  if (props.questionId !== undefined) {
+    var storeAnswers = props.answers
+    return (
+      <div>
+        {!moreAnswers ?
+          (
+            <div>
+              {answers.slice(0, 2).map((answer, index) =>
+              (renderAnswer(answer, index)))}
+              {answers.length > 2 ? <a id='moreAnswers' onClick={getMore}>More answers...</a> : null}
+            </div>
+          )
+          :
+          (
+            <div>
+                {answers.map((answer, index) => (renderAnswer(answer, index)))}
+                {answers.length > 2 ? <a id='moreAnswers' onClick={collapse}>Collapse answers</a> : null}
+            </div>
+          )
+
+        }
+      </div>
+    )
+  } else {
+    return (<div>Loading answers...</div>)
   }
+
 }
 
 export default Answers

--- a/client/src/components/QandA/Questions.js
+++ b/client/src/components/QandA/Questions.js
@@ -1,0 +1,218 @@
+import React, { Fragment, useEffect, useState } from 'react';
+import axios from 'axios';
+import Answers from './Answers.js'
+import AddQuestion from './AddQuestion.js'
+import AddAnswer from './AddAnswer.js'
+import SearchQuestions from './SearchQuestions.js'
+import ProductAPI from '../../Utils/ProductAPI';
+import { QuestionsContainer, QAContainer, QuestionCardsContainer, ThemeToggle, QuestionHead } from '../../Styles'
+
+const Questions = (props) => {
+  const [questions, setQuestions] = useState([]);
+  const [questionLength, setQuestionLength] = useState(2);
+  const [searchQuestionLength, setSearchQuestionLength] = useState(2);
+  const [moreQuestions, setMoreQuestions] = useState(false);
+  const [moreSearchedQuestions, setMoreSearchedQuestions] = useState(false);
+  const [questionMarkedHelpful, setQuestionMarkedHelpful] = useState([]);
+  const [qReported, setQReported] = useState([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState([]);
+
+  useEffect(() => {
+    setQuestionLength(2)
+    setSearchQuestionLength(2)
+    setMoreQuestions(false)
+    setMoreSearchedQuestions(false)
+    setSearchQuery('')
+    setSearchResults([])
+    getQuestions();
+  }, [props.productId])
+
+
+  const getQuestions = () => {
+    const qid = props.productId
+    axios.get(`qa/questions?product_id=${qid}&count=50`)
+    .then((question) => {
+      setQuestions(question.data.results)
+      console.log(question)
+    })
+  }
+
+  // shouldComponentUpdate(nextProps, nextState) {
+  //   if (this.props.productId !== nextProps.productId) {
+  //     console.log('qa Re')
+  //     return true;
+  //   } if (this.props.name !== nextProps.name) {
+  //     return true;
+  //   }
+  //   console.log('qa NO RErender');
+  //   console.log(this.props.productId)
+  //   console.log(this.props.name)
+  //   return false;
+  // }
+
+  const markHelpful = (question) => {
+    const prevMarked = questionMarkedHelpful
+    const qid = question.question_id;
+    if (prevMarked.includes(question.question_id)) {
+      return;
+    } else {
+      setQuestionMarkedHelpful([...prevMarked, question.question_id])
+      axios.put(`qa/questions/${qid}/helpful`, null)
+      question.question_helpfulness += 1
+    }
+  }
+
+  const filterQuestions = (event) => {
+    const queryString = event.target.value
+    setSearchQuery(queryString)
+    setMoreSearchedQuestions(false)
+    setSearchQuestionLength(2)
+    if (queryString.length >= 3) {
+      const match = questions.filter ((question) =>
+        question.question_body.toLowerCase().includes(queryString.toLowerCase()))
+        setSearchResults(match)
+    } else {
+      setSearchResults(questions)
+    }
+  }
+
+  const reportQuestion = (question) => {
+    const prevReported = qReported;
+    const qid = question.question_id;
+    setQReported([...prevReported, question.question_id])
+    axios.put(`qa/questions/${qid}/report`, null)
+    question.reported = true;
+  }
+
+  const escape = (html) => {
+    return String(html)
+      .replace(new RegExp("&"+"#"+"x27;", "g"), "'")
+  }
+
+  const renderQuestion = (question, index, product) => {
+    const tempBody = (escape(question.question_body))
+    const report = (qReported.includes(question.question_id))
+    const qDate = new Date(question.question_date)
+    return (
+      <div className='Question' key={index}>
+        <QuestionHead>
+          <p id='questionBody'> Q: {tempBody}</p>
+          <span id='qHelpful'>Helpful?
+            <span id='helpfulButton' onClick={() => markHelpful(question)}> Yes </span>
+            ({question.question_helpfulness}) | <AddAnswer question={question}/>
+          </span>
+        </QuestionHead>
+
+        <Answers key={index} questionId={question.question_id}/>
+        <div className='askerInfo'>
+          Asked by: {' '}{question.asker_name},{' '}{qDate.toDateString().substring(4)}{' '}|{' '}
+          {!report ?
+              (
+              <span id='reportButton' onClick={() => reportQuestion(question)}>Report</span>
+              ) :
+              (
+              <span>Reported</span>
+              )
+            }
+        </div>
+      </div>
+    )
+  }
+
+  const addMore = (event) => {
+    if (event.target.value === 'search') {
+      const addSearch = searchQuestionLength + 2
+      if (addSearch >= searchResults.length) {
+        setMoreSearchQuestions(true)
+        setSearchQuestionLength(addSearch)
+      } else {
+        setSearchQuestionLength(addSearch)
+      }
+    }
+    const add = questionLength + 2
+    if (add >= questions.length) {
+      setMoreQuestions(true)
+      setQuestionLength(add)
+    } else
+      setQuestionLength(add)
+  }
+
+    // if (this.state.name !== '') {
+  return (
+  <QAContainer>
+    {questions.length > 0 ?
+    (
+    <Fragment>
+    <QuestionsContainer>
+      <h2>Questions and Answers</h2>
+      <SearchQuestions currentProductId={props.productId} filterQuestions={filterQuestions}/>
+      <QuestionCardsContainer>
+        {searchQuery.length >= 3 ? (
+          <Fragment>
+            {searchResults.slice(0, searchQuestionLength).map((question, index) =>
+            (renderQuestion(question, index)))}
+          </Fragment>
+        )
+        :
+        (<Fragment>
+            {questions.slice(0, questionLength).map((question, index) =>
+            (renderQuestion(question, index)))}
+        </Fragment>
+
+        )}
+      </QuestionCardsContainer>
+    </QuestionsContainer>
+    <QuestionsContainer>
+    {searchResults.length > 0 && searchQuery.length >=3 ? (
+      <Fragment>
+        {!moreSearchedQuestions && searchResults.length >  2 ?
+        (
+          <div>
+            <button id='moreQuestions' value={'search'} onClick={addMore}>MORE ANSWERED QUESTIONS</button>
+            <AddQuestion currentProductId={props.productId}/>
+          </div>
+        )
+        :
+        <AddQuestion currentProductId={props.productId}/>
+        }
+      </Fragment>
+      )
+      :
+      (
+      <Fragment>
+        {!moreQuestions && questions.length >  2?
+        (
+          <div>
+            <button id='moreQuestions' onClick={addMore}>MORE ANSWERED QUESTIONS</button>
+            <AddQuestion currentProductId={props.productId }/>
+          </div>
+        )
+        :
+        <AddQuestion currentProductId={props.productId}/>
+      }
+        </Fragment>
+    )}
+
+    </QuestionsContainer>
+    </Fragment>
+  )
+  :
+  (
+  <QuestionsContainer>
+    <h2>Questions and Answers</h2>
+    <h4>There are currently no questions... Please add a question!</h4>
+    <AddQuestion currentProductId={props.productId}/>
+  </QuestionsContainer>
+
+  )
+  }
+  </QAContainer>
+  )
+// } else {
+//   return (<div>Loading questions</div>)
+// }
+}
+
+
+export default Questions;

--- a/client/src/components/QandA/SearchQuestions.js
+++ b/client/src/components/QandA/SearchQuestions.js
@@ -1,6 +1,10 @@
-import React, {Fragment} from 'react';
+import React, {Fragment, useEffect} from 'react';
 
 const SearchQuestions = (props) => {
+
+  useEffect(() => {
+    document.getElementById('searchQuestionInput').value = '';
+  }, [props.currentProductId])
     return (
       <Fragment>
         <form className='searchQuestion'>

--- a/client/src/components/QandA/index.js
+++ b/client/src/components/QandA/index.js
@@ -1,207 +1,30 @@
-import React, { Fragment } from 'react';
-import axios from 'axios';
-import Answers from './Answers.js'
-import AddQuestion from './AddQuestion.js'
-import AddAnswer from './AddAnswer.js'
-import SearchQuestions from './SearchQuestions.js'
-import { QuestionsContainer, QAContainer, QuestionCardsContainer, ThemeToggle, QuestionHead } from '../../Styles'
+import React, { Fragment, useState, useEffect, useMemo } from 'react';
+import ProductAPI from '../../Utils/ProductAPI';
+import Questions from './Questions.js';
 
-class QandA extends React.Component {
-  constructor(props) {
-    super(props)
+const QandA = ({store}) => {
+  const [productId, setProductId] = useState(store.state.currentProductId)
+  // const [name, setName] = useState('')
 
-    this.state = {
-      questions: [],
-      questionLength: 2,
-      searchQuestionLength: 2,
-      moreQuestions: false,
-      moreSearchedQuestions: false,
-      questionMarkedHelpful: [],
-      qReported: [],
-      searchQuery: '',
-      searchResults: []
-    }
-    this.addMore = this.addMore.bind(this)
-    this.renderQuestion = this.renderQuestion.bind(this)
-    this.markHelpful = this.markHelpful.bind(this)
-    this.reportQuestion = this.reportQuestion.bind(this)
-    this.escape = this.escape.bind(this)
-    this.getQuestions = this.getQuestions.bind(this)
-    this.filterQuestions = this.filterQuestions.bind(this)
+  useEffect(() => {
+    ProductAPI.getProduct(store.state.currentProductId)
+      .then((results) => {
+        console.log(store.state.currentProductId)
+        console.log(results)
+        setProductId(results.currentProductId)
+        // setName(results.product.name)
+      })
+  }, [store.state.currentProductId]);
+
+  if (productId !== undefined) {
+    return (<Questions productId={productId}/>)
+  } else {
+    return <div>Loading!!!</div>
   }
 
-  getQuestions() {
-    const qid = this.props.store.state.currentProductId
-    axios.get(`qa/questions?product_id=${qid}&count=50`)
-    .then((question) => {
-      this.setState({questions: question.data.results})
-    })
-  }
-
-  componentDidMount() {
-    this.getQuestions()
-  }
-
-  markHelpful(question) {
-    const prevMarked = this.state.questionMarkedHelpful
-    const qid = question.question_id;
-    if (prevMarked.includes(question.question_id)) {
-      return;
-    } else {
-      this.setState({questionMarkedHelpful: [...prevMarked, question.question_id]})
-      axios.put(`qa/questions/${qid}/helpful`, null)
-      question.question_helpfulness += 1
-    }
-  }
-
-  filterQuestions(event) {
-    const queryString = event.target.value
-    this.setState({searchQuery: queryString, moreSearchedQuestions: false, searchQuestionLength: 2})
-    if (queryString.length >= 3) {
-      const match = this.state.questions.filter ((question) =>
-        question.question_body.toLowerCase().includes(queryString.toLowerCase()))
-        this.setState({searchResults: match})
-    } else {
-      this.setState({searchResults: this.state.questions})
-    }
-  }
-
-  reportQuestion(question) {
-    const prevReported = this.state.qReported;
-    const qid = question.question_id;
-    this.setState({qReported: [...prevReported, question.question_id]})
-    axios.put(`qa/questions/${qid}/report`, null)
-    question.reported = true;
-  }
-
-  escape (html) {
-    return String(html)
-      .replace(new RegExp("&"+"#"+"x27;", "g"), "'")
-  }
-
-  renderQuestion(question, index, product) {
-    const tempBody = (this.escape(question.question_body))
-    const report = (this.state.qReported.includes(question.question_id))
-    const qDate = new Date(question.question_date)
-    return (
-      <div className='Question' key={index}>
-        <QuestionHead>
-          <p id='questionBody'> Q: {tempBody}</p>
-          <span id='qHelpful'>Helpful?
-            <span id='helpfulButton' onClick={() => this.markHelpful(question)}> Yes </span>
-            ({question.question_helpfulness}) | <AddAnswer question={question} name={product}/>
-          </span>
-        </QuestionHead>
-
-        <Answers key={index} questionId={question.question_id}/>
-        <div className='askerInfo'>
-          Asked by: {' '}{question.asker_name},{' '}{qDate.toDateString().substring(4)}{' '}|{' '}
-          {!report ?
-              (
-              <span id='reportButton' onClick={() => this.reportQuestion(question)}>Report</span>
-              ) :
-              (
-              <span>Reported</span>
-              )
-            }
-        </div>
-      </div>
-    )
-  }
-
-  addMore(event) {
-    if (event.target.value === 'search') {
-      const addSearch = this.state.searchQuestionLength + 2
-      if (addSearch >= this.state.searchResults.length) {
-        this.setState({moreSearchQuestions: true, searchQuestionLength: addSearch})
-      } else {
-        this.setState({searchQuestionLength: addSearch})
-      }
-    }
-    const add = this.state.questionLength + 2
-    if (add >= this.state.questions.length) {
-      this.setState({moreQuestions: true, questionLength: add})
-    } else
-      this.setState({questionLength: add})
-  }
-
-  render () {
-    if (this.props.store.state.product !== undefined) {
-      var store = this.props.store.state
-      return (
-      <QAContainer>
-        {this.state.questions.length > 0 ?
-        (
-        <Fragment>
-        <QuestionsContainer>
-          <h2>Questions and Answers</h2>
-          <SearchQuestions filterQuestions={this.filterQuestions}/>
-          <QuestionCardsContainer>
-            {this.state.searchQuery.length >= 3 ? (
-              <Fragment>
-                {this.state.searchResults.slice(0, this.state.searchQuestionLength).map((question, index) =>
-                (this.renderQuestion(question, index, store.product.name)))}
-              </Fragment>
-            )
-            :
-            (<Fragment>
-                {this.state.questions.slice(0, this.state.questionLength).map((question, index) =>
-                (this.renderQuestion(question, index, store.product.name)))}
-            </Fragment>
-
-            )}
-          </QuestionCardsContainer>
-        </QuestionsContainer>
-        <QuestionsContainer>
-        {this.state.searchResults.length > 0 && this.state.searchQuery.length >=3 ? (
-          <Fragment>
-            {!this.state.moreSearchedQuestions && this.state.searchResults.length >  2 ?
-            (
-              <div>
-                <button id='moreQuestions' value={'search'} onClick={this.addMore}>MORE ANSWERED QUESTIONS</button>
-                <AddQuestion currentProductId={store.currentProductId } name={store.product.name}/>
-              </div>
-            )
-            :
-            <AddQuestion currentProductId={store.currentProductId} name={store.product.name}/>
-           }
-          </Fragment>
-          )
-          :
-          (
-          <Fragment>
-            {!this.state.moreQuestions && this.state.questions.length >  2?
-            (
-              <div>
-                <button id='moreQuestions' onClick={this.addMore}>MORE ANSWERED QUESTIONS</button>
-                <AddQuestion currentProductId={store.currentProductId } name={store.product.name}/>
-              </div>
-            )
-            :
-            <AddQuestion currentProductId={store.currentProductId} name={store.product.name}/>
-          }
-            </Fragment>
-        )}
-
-        </QuestionsContainer>
-        </Fragment>
-      )
-      :
-      (
-      <QuestionsContainer>
-        <h2>Questions and Answers</h2>
-        <h4>There are currently no questions... Please add a question!</h4>
-        <AddQuestion currentProductId={store.currentProductId} name={store.product.name}/>
-      </QuestionsContainer>
-
-      )
-      }
-      </QAContainer>
-      )
-    } else {
-      return (<div>Loading questions</div>)
-    }
-  }
 }
 
-export default QandA;
+
+export default QandA
+
+


### PR DESCRIPTION
Questions and Answers (not modals) are refactored to use hooks. UseEffects are applied on product change and questionid change respectively. Removed the name passed down from props since the API call takes too long and my widget breaks looking for the property that doesn't yet pass down.